### PR TITLE
fix some bugs.

### DIFF
--- a/plugin/TermSingleton.vim
+++ b/plugin/TermSingleton.vim
@@ -9,22 +9,22 @@
 " TODO: "vim -" is not supported
 
 if exists("g:loaded_termsingleton")
-   finish
+    finish
 endif
 
 if $VIM_SERVERNAME != ''
-   try
-      if argc() > 0
-	 silent call remote_send($VIM_SERVERNAME, "\<C-\><C-N>:tab drop " . join(map(argv(), 'fnamemodify(v:val, ":p")')) . "<CR><C-o>i\<C-\><C-N><C-i>")
-      endif
-      quitall
-   catch
-      echo "TermSingleton: Can't use outside Vim (maybe because of sandbox or restricted-mode)"
-   endtry
+    try
+        if argc() > 0
+            silent call remote_send($VIM_SERVERNAME, "<C-W>:tab drop " . join(map(argv(), 'fnamemodify(v:val, ":p")')) . "<CR>")
+        endif
+        quitall
+    catch
+        echo "TermSingleton: Can't use outside Vim (maybe because of sandbox or restricted-mode)"
+    endtry
 endif
 
 if has('clientserver') && empty(v:servername)
-   call remote_startserver("VIM")
+    call remote_startserver("VIM")
 endif
 
 let g:loaded_termsingleton = 1


### PR DESCRIPTION
- format: indent should be four :)
- terminal should stick to insert mode. we can do this by using \<C-W\> instead of \<C-\\\>\<C-N\>
- somehow we can't jump to terminal by \<C-o\>, so the previous version
has a bug. we can avoid \<C-o\> by using \<C-W\>. This is related to the bug
above.